### PR TITLE
Hotfix/Collapsed story title fix

### DIFF
--- a/lib/extension/main.js
+++ b/lib/extension/main.js
@@ -75,7 +75,7 @@ let storyTypes = [{
     setupTimer(
       $el,
       parseInt($el.data('id')),
-      $el.find('span.story_name').text(),
+      $el.find('span.story_name .tracker_markup').text(),
       'harvest-timer-collapsed',
       $el.find('.label'),
       $el


### PR DESCRIPTION
Minor fix to get the story title when the story is collapsed.  Currently it gets all the owners and labels.